### PR TITLE
Emit C0 control codes for all single byte control codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Each generic C1 code gets emitted as an `c1` event with its raw 2-byte sequence:
 $stream->on('c1', function ($sequence) { … });
 ```
 
+All other [C0 control codes](https://en.wikipedia.org/wiki/C0_and_C1_control_codes#C0_.28ASCII_and_derivatives.29),
+also known as [ASCII control codes](https://en.wikipedia.org/wiki/ASCII#ASCII_control_code_chart),
+are supported by just emitting their single-byte value.
+Each generic C0 code gets emitted as an `c0` event with its raw single-byte value:
+
+```php
+$stream->on('c0', function ($code) {
+    if ($code === "\n") {
+        echo 'ENTER pressed';
+    }
+});
+```
+
 ## Install
 
 The recommended way to install this library is [through Composer](https://getcomposer.org).

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "clue/term-react",
     "description": "Streaming terminal emulator, built on top of React PHP",
-    "keywords": ["terminal", "control codes", "xterm", "csi", "osc", "apc", "dps", "pm", "c1", "streaming", "ReactPHP"],
+    "keywords": ["terminal", "control codes", "xterm", "csi", "osc", "apc", "dps", "pm", "C1", "C0", "streaming", "ReactPHP"],
     "homepage": "https://github.com/clue/php-term-react",
     "license": "MIT",
     "authors": [

--- a/examples/stdin-codes.php
+++ b/examples/stdin-codes.php
@@ -25,6 +25,8 @@ $decoder = function ($code) {
 
 $parser->on('csi', $decoder);
 $parser->on('osc', $decoder);
+$parser->on('c1', $decoder);
+$parser->on('c0', $decoder);
 
 $parser->on('data', function ($bytes) {
     echo 'Data: ' . $bytes . PHP_EOL;

--- a/tests/ControlCodeParserTest.php
+++ b/tests/ControlCodeParserTest.php
@@ -36,6 +36,14 @@ class ControlCodeParserTest extends TestCase
         $this->assertEquals('helloworld', $buffer);
     }
 
+    public function testEmitsC0AsOneChunk()
+    {
+        $this->parser->on('data', $this->expectCallableNever());
+        $this->parser->on('c0', $this->expectCallableOnce("\n"));
+
+        $this->input->emit('data', array("\n"));
+    }
+
     public function testEmitsCsiAsOneChunk()
     {
         $this->parser->on('data', $this->expectCallableNever());
@@ -69,6 +77,14 @@ class ControlCodeParserTest extends TestCase
 
         $this->input->emit('data', array("\x1B[2"));
         $this->input->emit('data', array("A"));
+    }
+
+    public function testEmitsDataAndC0()
+    {
+        $this->parser->on('data', $this->expectCallableOnceWith("hello world"));
+        $this->parser->on('c0', $this->expectCallableOnceWith("\n"));
+
+        $this->input->emit('data', array("hello world\n"));
     }
 
     public function testEmitsCsiAndData()


### PR DESCRIPTION
Closes #8

This is technically a BC break with the current unstable master, as C0 control codes such as `\n` and `\t` no longer end up in the data stream.
