### PR TITLE
Fix processing events when input writes during data event

### DIFF
--- a/src/ControlCodeParser.php
+++ b/src/ControlCodeParser.php
@@ -121,6 +121,7 @@ class ControlCodeParser extends EventEmitter implements ReadableStreamInterface
                 $this->buffer = substr($this->buffer, $c0);
 
                 $this->emit('data', array($data));
+                continue;
             }
 
             // C0 is now at start of buffer


### PR DESCRIPTION
This is a rare edge case that only triggered under these circumstances:
- A control codes is in the middle of the buffer
- A consumer listens for the data event
- The consumer pushes data to the input stream during the event handler
