### PR TITLE
Simplify examples by updating to new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It wraps a given `ReadableStreamInterface` and exposes its plain data through
 the same interface.
 
 ```php
-$stdin = new ReadableResourceStream(STDIN, $loop);
+$stdin = new React\Stream\ReadableResourceStream(STDIN);
 
 $stream = new ControlCodeParser($stdin);
 

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/stream": "^1.0 || ^0.7"
+        "react/stream": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3"
+        "react/event-loop": "^1.2"
     }
 }

--- a/examples/random-colors.php
+++ b/examples/random-colors.php
@@ -11,14 +11,11 @@
 // with random colors:
 // $ phpunit --color=always | php random-colors.php
 
-use React\EventLoop\Factory;
 use Clue\React\Term\ControlCodeParser;
 use React\Stream\ReadableResourceStream;
 use React\Stream\WritableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = Factory::create();
 
 if (function_exists('posix_isatty') && posix_isatty(STDIN)) {
     // Disable icanon (so we can fread each keypress) and echo (we'll do echoing here instead)
@@ -26,10 +23,10 @@ if (function_exists('posix_isatty') && posix_isatty(STDIN)) {
 }
 
 // process control codes from STDIN
-$stdin = new ReadableResourceStream(STDIN, $loop);
+$stdin = new ReadableResourceStream(STDIN);
 $parser = new ControlCodeParser($stdin);
 
-$stdout = new WritableResourceStream(STDOUT, $loop);
+$stdout = new WritableResourceStream(STDOUT);
 
 // pass all c0 codes through to output
 $parser->on('c0', array($stdout, 'write'));
@@ -55,5 +52,3 @@ $parser->pipe($stdout, array('end' => false));
 
 // start with random color
 $stdin->emit('data', array("\033[m"));
-
-$loop->run();

--- a/examples/remove-codes.php
+++ b/examples/remove-codes.php
@@ -8,14 +8,11 @@
 // codes like this:
 // $ phpunit --color=always | php remove-codes.php
 
-use React\EventLoop\Factory;
 use Clue\React\Term\ControlCodeParser;
 use React\Stream\ReadableResourceStream;
 use React\Stream\WritableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = Factory::create();
 
 if (function_exists('posix_isatty') && posix_isatty(STDIN)) {
     // Disable icanon (so we can fread each keypress) and echo (we'll do echoing here instead)
@@ -23,11 +20,11 @@ if (function_exists('posix_isatty') && posix_isatty(STDIN)) {
 }
 
 // process control codes from STDIN
-$stdin = new ReadableResourceStream(STDIN, $loop);
+$stdin = new ReadableResourceStream(STDIN);
 $parser = new ControlCodeParser($stdin);
 
 // pipe data from STDIN to STDOUT without any codes
-$stdout = new WritableResourceStream(STDOUT, $loop);
+$stdout = new WritableResourceStream(STDOUT);
 $parser->pipe($stdout);
 
 // only forward \r, \n and \t
@@ -36,5 +33,3 @@ $parser->on('c0', function ($code) use ($stdout) {
         $stdout->write($code);
     }
 });
-
-$loop->run();

--- a/examples/stdin-codes.php
+++ b/examples/stdin-codes.php
@@ -9,13 +9,10 @@
 // codes like this:
 // $ phpunit --color=always | php stdin-codes.php
 
-use React\EventLoop\Factory;
 use Clue\React\Term\ControlCodeParser;
 use React\Stream\ReadableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-$loop = Factory::create();
 
 if (function_exists('posix_isatty') && posix_isatty(STDIN)) {
     // Disable icanon (so we can fread each keypress) and echo (we'll do echoing here instead)
@@ -23,7 +20,7 @@ if (function_exists('posix_isatty') && posix_isatty(STDIN)) {
 }
 
 // process control codes from STDIN
-$stdin = new ReadableResourceStream(STDIN, $loop);
+$stdin = new ReadableResourceStream(STDIN);
 $parser = new ControlCodeParser($stdin);
 
 $decoder = function ($code) {
@@ -42,5 +39,3 @@ $parser->on('c0', $decoder);
 $parser->on('data', function ($bytes) {
     echo 'Data: ' . $bytes . PHP_EOL;
 });
-
-$loop->run();

--- a/tests/FunctionalControlCodeParserTest.php
+++ b/tests/FunctionalControlCodeParserTest.php
@@ -3,16 +3,14 @@
 namespace Clue\Tests\React\Term;
 
 use Clue\React\Term\ControlCodeParser;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableResourceStream;
 
 class FunctionalControlCodeParserTest extends TestCase
 {
     public function testPipingReadme()
     {
-        $loop = Factory::create();
-
-        $input = new ReadableResourceStream(fopen(__DIR__ . '/../README.md', 'r+'), $loop);
+        $input = new ReadableResourceStream(fopen(__DIR__ . '/../README.md', 'r+'));
         $parser = new ControlCodeParser($input);
 
         $buffer = '';
@@ -20,7 +18,7 @@ class FunctionalControlCodeParserTest extends TestCase
             $buffer .= $chunk;
         });
 
-        $loop->run();
+        Loop::run();
 
         $readme = str_replace(
             "\n",


### PR DESCRIPTION
This changeset simplifies usage by using the new [default loop](https://github.com/reactphp/event-loop#loop).
Builds on top of https://github.com/reactphp/event-loop/pull/229, reactphp/event-loop#232 and reactphp/stream#159