### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## 1.2.0 (2018-07-09)
 
-*   Feature: Forward compatiblity with EventLoop v0.5 and upcoming v1.0.
+*   Feature: Forward compatibility with EventLoop v0.5 and upcoming v1.0.
     (#28 by @clue)
 
 *   Improve test suite by updating Travis config to test against legacy PHP 5.3 through PHP 7.2.

--- a/src/ControlCodeParser.php
+++ b/src/ControlCodeParser.php
@@ -31,7 +31,7 @@ class ControlCodeParser extends EventEmitter implements ReadableStreamInterface
      * C1 types in 8 bit are currently not supported, as they require special
      * care with regards to whether UTF-8 mode is enabled. So far this has
      * turned out to be a non-issue because most terminal emulators *accept*
-     * boths formats, but usually *send* in 7 bit mode exclusively.
+     * both formats, but usually *send* in 7 bit mode exclusively.
      */
     private $types = array(
         '[' => 'csi',


### PR DESCRIPTION
This pull request fixes a few typos with the help of https://github.com/szepeviktor/typos-on-you.

Builds on top of #14 and #26.